### PR TITLE
include role in my-sessions API response

### DIFF
--- a/Mentor-Matching-Platform/client/src/pages/Mentorship/MentorshipSessionDetailPage.js
+++ b/Mentor-Matching-Platform/client/src/pages/Mentorship/MentorshipSessionDetailPage.js
@@ -4,38 +4,43 @@ import { useNavigate, useParams } from 'react-router-dom';
 import SessionDetail from '../../components/Session/SessionDetail';
 
 /**
- * MentorshipSessionDetailPage fetches session details and manages apply/cancel logic.
- * It uses real API calls for fetching data and updating application status.
+ * MentorshipSessionDetailPage handles session detail display,
+ * role selection on apply, and cancel application with role info.
  */
 const MentorshipSessionDetailPage = () => {
   const { id } = useParams();
   const navigate = useNavigate();
+
   const [session, setSession] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [applied, setApplied] = useState(false);
 
+  // For new application: track selected role
+  const [role, setRole] = useState('mentee');
+  // For existing application: record applied role
+  const [appliedRole, setAppliedRole] = useState('');
+
   useEffect(() => {
-    // Load session detail and check application status
     const loadData = async () => {
       try {
         // Fetch session detail
         const respSession = await fetch(`/api/sessions/${id}`, { credentials: 'include' });
-        if (!respSession.ok) {
-          throw new Error(`Failed to load session (status ${respSession.status})`);
-        }
+        if (!respSession.ok) throw new Error(`Failed to load session (status ${respSession.status})`);
         const sessionData = await respSession.json();
         setSession(sessionData);
 
-        // Fetch user's applied sessions
+        // Fetch user's applications
         const respMy = await fetch('/api/my-sessions', { credentials: 'include' });
-        if (!respMy.ok) {
-          throw new Error(`Failed to load user sessions (status ${respMy.status})`);
-        }
+        if (!respMy.ok) throw new Error(`Failed to load user sessions (status ${respMy.status})`);
         const mySessions = await respMy.json();
-        // Determine if current session is applied
-        const isApplied = mySessions.some((s) => s.id.toString() === id);
-        setApplied(isApplied);
+
+        // Check if applied and record role
+        const myApp = mySessions.find((s) => s.id.toString() === id);
+        if (myApp) {
+          setApplied(true);
+          setAppliedRole(myApp.role);
+        }
       } catch (err) {
         console.error(err);
         setError(err);
@@ -46,16 +51,19 @@ const MentorshipSessionDetailPage = () => {
     loadData();
   }, [id]);
 
-  // Handle apply action
+  // Apply with selected role
   const handleApply = async () => {
     try {
       const resp = await fetch(`/api/sessions/${id}/apply`, {
         method: 'POST',
-        credentials: 'include'
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role })
       });
       if (resp.ok) {
         alert('Application sent successfully!');
         setApplied(true);
+        setAppliedRole(role);
         navigate('/sessions');
       } else {
         const data = await resp.json();
@@ -67,7 +75,7 @@ const MentorshipSessionDetailPage = () => {
     }
   };
 
-  // Handle cancel application
+  // Cancel application
   const handleCancelApply = async () => {
     try {
       const resp = await fetch(`/api/sessions/${id}/apply`, {
@@ -89,35 +97,23 @@ const MentorshipSessionDetailPage = () => {
     }
   };
 
-  if (loading) {
-    return <div className="container mx-auto px-4 py-8">Loading...</div>;
-  }
-
-  if (error) {
-    return (
-      <div className="container mx-auto px-4 py-8 text-red-600">
-        Error: {error.message}
-      </div>
-    );
-  }
+  if (loading) return <div className="container mx-auto px-4 py-8">Loading...</div>;
+  if (error) return <div className="container mx-auto px-4 py-8 text-red-600">Error: {error.message}</div>;
 
   return (
     <div className="max-w-4xl mx-auto p-6">
-      {/* Render session details */}
       <SessionDetail session={session} />
 
-      {/* Action buttons */}
-      <div className="mt-6 text-center space-x-4">
+      <div className="mt-6 text-center space-y-4">
         {applied ? (
-          <>  
-            {/* Disabled applied button */}
+          <>
+            <div>Applied Role: <strong>{appliedRole}</strong></div>
             <button
               disabled
               className="bg-gray-500 cursor-not-allowed font-semibold py-2 px-4 rounded"
             >
               Applied
             </button>
-            {/* Cancel apply button */}
             <button
               onClick={handleCancelApply}
               className="bg-btnorange text-white font-semibold py-2 px-4 rounded"
@@ -126,13 +122,35 @@ const MentorshipSessionDetailPage = () => {
             </button>
           </>
         ) : (
-          // Apply button for new applications
-          <button
-            onClick={handleApply}
-            className="bg-btnorange text-white font-semibold py-2 px-4 rounded"
-          >
-            Apply
-          </button>
+          <>
+            {/* Role selection */}
+            <div className="space-x-4">
+              <label>
+                <input
+                  type="radio"
+                  name="role"
+                  value="mentor"
+                  checked={role === 'mentor'}
+                  onChange={() => setRole('mentor')}
+                /> Mentor
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="role"
+                  value="mentee"
+                  checked={role === 'mentee'}
+                  onChange={() => setRole('mentee')}
+                /> Mentee
+              </label>
+            </div>
+            <button
+              onClick={handleApply}
+              className="bg-btnorange text-white font-semibold py-2 px-4 rounded"
+            >
+              Apply
+            </button>
+          </>
         )}
       </div>
     </div>

--- a/Mentor-Matching-Platform/server/routes/sessions.js
+++ b/Mentor-Matching-Platform/server/routes/sessions.js
@@ -120,7 +120,11 @@ router.post('/sessions/:id/apply', ensureAuthenticated, (req, res) => {
       return res.status(409).json({ error: 'Already applied' });
     }
     // Insert new application
-    const {role} = req.body;
+    const { role } = req.body;
+    const allowedRoles = ['mentor', 'mentee'];
+    if (!allowedRoles.includes(role)) {
+      return res.status(400).json({ error: 'Invalid role. Allowed values are "mentor" or "mentee".' });
+    }
     const insertSql = `
       INSERT INTO applications (user_id, session_id, role)
       VALUES (?, ?, ?)

--- a/Mentor-Matching-Platform/server/routes/sessions.js
+++ b/Mentor-Matching-Platform/server/routes/sessions.js
@@ -31,6 +31,7 @@ router.get('/my-sessions', ensureAuthenticated, (req, res) => {
            s.description,
            s.start_date  AS startDate,
            s.end_date    AS endDate,
+            a.role     AS role,
            a.status      
     FROM applications a
     JOIN sessions s ON s.id = a.session_id
@@ -119,11 +120,12 @@ router.post('/sessions/:id/apply', ensureAuthenticated, (req, res) => {
       return res.status(409).json({ error: 'Already applied' });
     }
     // Insert new application
+    const {role} = req.body;
     const insertSql = `
-      INSERT INTO applications (user_id, session_id,  role)
-      VALUES (?, ?, 'mentor')
+      INSERT INTO applications (user_id, session_id, role)
+      VALUES (?, ?, ?)
     `;
-    db.run(insertSql, [userId, sessionId], function(err) {
+    db.run(insertSql, [userId, sessionId, role], function(err) {
       if (err) {
         console.error(err);
         return res.status(500).json({ error: 'Internal Server Error' });


### PR DESCRIPTION


### 🗂️ Backend  
- **My Sessions API**  
  - Updated `GET /api/my-sessions` to include `a.role AS role` in the SELECT, so responses now carry the `role` field.  

---

### 🖥️ Frontend  
- **Role Selection on Apply**  
  - In `MentorshipSessionDetailPage`, added radio buttons for `mentor`/`mentee`.  
  - Sends `{ role }` in the POST body to `/api/sessions/:id/apply`.  
- **Display Applied Role**  
  - Reads `role` from `GET /api/my-sessions` and shows it under “Applied Role:”  

