### PR TITLE
Account mentorship preferences

### DIFF
--- a/Mentor-Matching-Platform/client/src/components/Survey/MatchingLifestyle.js
+++ b/Mentor-Matching-Platform/client/src/components/Survey/MatchingLifestyle.js
@@ -15,8 +15,6 @@ const MatchingLifestyle = () => {
         }
       });
   }, []);
-  
-
 
   const [responses, setResponses] = useState({
     physicalExerciseFrequency: '',
@@ -43,12 +41,15 @@ const MatchingLifestyle = () => {
 
   const handleNext = () => {
     console.log("🔥 Matching Lifestyle Responses:", responses);
-  
+
+    const sessionId = localStorage.getItem("sessionId") || "9999";
+    const role = localStorage.getItem("selectedRole") || "mentee";
+
     fetch('/api/save-lifestyle', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ answers: responses })
+      body: JSON.stringify({ sessionId, role, answers: responses })
     })
       .then(res => res.json())
       .then(data => {
@@ -65,8 +66,7 @@ const MatchingLifestyle = () => {
         alert("Server error. Please try again later.");
       });
   };
-  
-  
+
   const QuestionSlider = ({ label, name }) => (
     <div className="mb-6">
       <label className="block font-semibold text-lg mb-1 text-gray-800">{label}</label>

--- a/Mentor-Matching-Platform/client/src/components/Survey/MatchingPreferences.js
+++ b/Mentor-Matching-Platform/client/src/components/Survey/MatchingPreferences.js
@@ -26,7 +26,6 @@ const transplantOptions = [
     { value: 'Walking', label: 'Walking' },
     { value: 'Board Games', label: 'Board Games' },
   ];
-  
 
 const MatchingPreferences = () => {
   const [formData, setFormData] = useState({
@@ -39,19 +38,19 @@ const MatchingPreferences = () => {
   });
 
   const [isLocked, setIsLocked] = useState(false);
-useEffect(() => {
-  fetch('/api/form-status', {
-    method: 'GET',
-    credentials: 'include',
-  })
-    .then(res => res.json())
-    .then(data => {
-      if (data.success && data.submitted) {
-        setIsLocked(true);
-      }
+  useEffect(() => {
+    fetch('/api/form-status', {
+      method: 'GET',
+      credentials: 'include',
     })
-    .catch(err => console.error("⚠️ Error checking submission status:", err));
-}, []);
+      .then(res => res.json())
+      .then(data => {
+        if (data.success && data.submitted) {
+          setIsLocked(true);
+        }
+      })
+      .catch(err => console.error("⚠️ Error checking submission status:", err));
+  }, []);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -96,42 +95,42 @@ useEffect(() => {
       </select>
 
       {/* Transplant Type */}
-<label className="block font-medium mb-1">Transplant Type</label>
-<Select
-  isMulti
-  options={transplantOptions}
-  disabled={isLocked}
-  value={transplantOptions.filter(option =>
-    formData.transplantType.includes(option.value)
-  )}
-  onChange={(selectedOptions) => {
-    setFormData(prev => ({
-      ...prev,
-      transplantType: selectedOptions.map(option => option.value),
-    }));
-  }}
-  className="mb-4"
-/>
+      <label className="block font-medium mb-1">Transplant Type</label>
+      <Select
+        isMulti
+        options={transplantOptions}
+        disabled={isLocked}
+        value={transplantOptions.filter(option =>
+          formData.transplantType.includes(option.value)
+        )}
+        onChange={(selectedOptions) => {
+          setFormData(prev => ({
+            ...prev,
+            transplantType: selectedOptions.map(option => option.value),
+          }));
+        }}
+        className="mb-4"
+      />
+
       {/* Year of Transplant */}
       <label className="block font-medium mb-1">Year of Transplant</label>
       <select
-  name="transplantYear"
-  value={formData.transplantYear}
-  onChange={handleChange}
-  disabled={isLocked}
-  className="w-full p-2 mb-4 border border-gray-300 rounded"
->
-  <option value="">Select Year</option>
-  {Array.from({ length: 40 }, (_, i) => {
-    const year = new Date().getFullYear() - i;
-    return (
-      <option key={year} value={year}>
-        {year}
-      </option>
-    );
-  })}
-</select>
-
+        name="transplantYear"
+        value={formData.transplantYear}
+        onChange={handleChange}
+        disabled={isLocked}
+        className="w-full p-2 mb-4 border border-gray-300 rounded"
+      >
+        <option value="">Select Year</option>
+        {Array.from({ length: 40 }, (_, i) => {
+          const year = new Date().getFullYear() - i;
+          return (
+            <option key={year} value={year}>
+              {year}
+            </option>
+          );
+        })}
+      </select>
 
       {/* I’m looking for... */}
       <label className="block font-medium mb-1">I am looking for:</label>
@@ -168,66 +167,65 @@ useEffect(() => {
 
       {/* Sports/Activity Interests */}
       <label className="block font-medium mb-1">Sports/Activities Interest</label>
-<Select
-  isMulti
-  isDisabled={isLocked}
-  name="sportsInterests"
-  options={sportsOptions}
-  value={sportsOptions.filter(option =>
-    formData.sportsInterests.includes(option.value)
-  )}
-  onChange={(selectedOptions) => {
-    setFormData(prev => ({
-      ...prev,
-      sportsInterests: selectedOptions.map(option => option.value),
-    }));
-  }}
-  className="mb-6"
-  classNamePrefix="select"
-/>
+      <Select
+        isMulti
+        isDisabled={isLocked}
+        name="sportsInterests"
+        options={sportsOptions}
+        value={sportsOptions.filter(option =>
+          formData.sportsInterests.includes(option.value)
+        )}
+        onChange={(selectedOptions) => {
+          setFormData(prev => ({
+            ...prev,
+            sportsInterests: selectedOptions.map(option => option.value),
+          }));
+        }}
+        className="mb-6"
+        classNamePrefix="select"
+      />
 
       <div className="flex justify-end mt-8">
-  <button
-    type="button"
-    disabled={isLocked}
-    onClick={async () => {
-        const payload = {
-          role: localStorage.getItem("selectedRole") || "mentee", // or fetch from global state
-          transplantType: formData.transplantType,
-          transplantYear: formData.transplantYear,
-          goals: formData.supportNeeds,
-          meetingPref: formData.meetingPreference,
-          sportsInterest: formData.sportsInterests,
-        };
-      
-        try {
-          const res = await fetch("/api/save-preferences", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            credentials: "include",
-            body: JSON.stringify(payload),
-          });
-      
-          const data = await res.json();
-      
-          if (data.success) {
-            window.location.href = '/survey/lifestyle';
-          } else {
-            alert("❌ Failed to save preferences.");
-          }
-        } catch (err) {
-          console.error("❌ Error saving preferences:", err);
-          alert("⚠️ Server error. Please try again.");
-        }
-      }}
-      
-    className="bg-orange-500 text-white px-6 py-2 rounded hover:bg-orange-600 flex items-center gap-2"
-  >
-    <span>Next</span>
-    <span>➔</span>
-  </button>
-</div>
+        <button
+          type="button"
+          disabled={isLocked}
+          onClick={async () => {
+            const payload = {
+              sessionId: localStorage.getItem("sessionId") || "9999",
+              role: localStorage.getItem("selectedRole") || "mentee",
+              transplantType: formData.transplantType,
+              transplantYear: formData.transplantYear,
+              goals: formData.supportNeeds,
+              meetingPref: formData.meetingPreference,
+              sportsInterest: formData.sportsInterests,
+            };
 
+            try {
+              const res = await fetch("/api/save-preferences", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                credentials: "include",
+                body: JSON.stringify(payload),
+              });
+
+              const data = await res.json();
+
+              if (data.success) {
+                window.location.href = '/survey/lifestyle';
+              } else {
+                alert("❌ Failed to save preferences.");
+              }
+            } catch (err) {
+              console.error("❌ Error saving preferences:", err);
+              alert("⚠️ Server error. Please try again.");
+            }
+          }}
+          className="bg-orange-500 text-white px-6 py-2 rounded hover:bg-orange-600 flex items-center gap-2"
+        >
+          <span>Next</span>
+          <span>➔</span>
+        </button>
+      </div>
     </div>
   );
 };

--- a/Mentor-Matching-Platform/client/src/components/Survey/SubmitForm.js
+++ b/Mentor-Matching-Platform/client/src/components/Survey/SubmitForm.js
@@ -1,5 +1,3 @@
-// src/components/Survey/SubmitForm.js
-
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import celebrationImg from '../../assets/submitpicture.png'; // replace with actual path
@@ -9,7 +7,6 @@ const SubmitForm = () => {
 
   return (
     <div className="max-w-4xl mx-auto px-6 py-12 text-center">
-
       <div className="bg-white rounded-lg shadow-md p-8">
         <img
           src={celebrationImg}
@@ -22,13 +19,12 @@ const SubmitForm = () => {
         </h1>
 
         <p className="text-gray-600 mb-2 max-w-xl mx-auto text-center">
-  Your mentorship application has been received.
-</p>
-<p className="text-gray-600 mb-6 max-w-xl mx-auto text-center">
-  Our team is reviewing it, and you’ll hear from us within 3–5 business days.<br />
-  We will contact you with details of your mentor match!
-</p>
-
+          Your mentorship application has been received.
+        </p>
+        <p className="text-gray-600 mb-6 max-w-xl mx-auto text-center">
+          Our team is reviewing it, and you’ll hear from us within 3–5 business days.<br />
+          We will contact you with details of your mentor match!
+        </p>
 
         <button
           onClick={() => navigate('/dashboard')}
@@ -37,26 +33,8 @@ const SubmitForm = () => {
           Back to Connections
         </button>
       </div>
-
-      <button
-  onClick={() => {
-    fetch('/api/match-mentee', {
-      method: 'GET',
-      credentials: 'include'
-    })
-      .then(res => res.json())
-      .then(data => console.log("Matches 🔥", data))
-      .catch(err => console.error("Error fetching matches:", err));
-  }}
-  className="bg-blue-500 text-white px-4 py-2 rounded"
->
-  Get My Matches
-</button>
-
     </div>
-    
   );
 };
-
 
 export default SubmitForm;

--- a/Mentor-Matching-Platform/client/src/components/Survey/SurveyStart.js
+++ b/Mentor-Matching-Platform/client/src/components/Survey/SurveyStart.js
@@ -40,6 +40,7 @@ const SurveyStart = () => {
   const handleRoleSelect = (role) => {
     setSelectedRole(role);
     localStorage.setItem('selectedRole', role);
+    localStorage.setItem('sessionId', '9999'); 
   };
 
   const handleNext = () => {

--- a/Mentor-Matching-Platform/server/routes/sessions.js
+++ b/Mentor-Matching-Platform/server/routes/sessions.js
@@ -4,19 +4,6 @@ const router = express.Router();
 const { ensureAuthenticated } = require('../middlewares/auth');
 const db = require('../db'); // sqlite3.Database instance
 
-// Create applications table if not exists
-db.run(`
-  CREATE TABLE IF NOT EXISTS applications (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    session_id INTEGER NOT NULL,
-    status TEXT NOT NULL DEFAULT 'in_progress' CHECK (status IN ('in_progress', 'approved')),
-    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
-  );
-`);
 
 /**
  * GET /api/my-sessions

--- a/Mentor-Matching-Platform/server/routes/survey.js
+++ b/Mentor-Matching-Platform/server/routes/survey.js
@@ -9,21 +9,32 @@ function isAuthenticated(req, res, next) {
   return res.status(401).json({ success: false, message: "Unauthorized" });
 }
 
-// Save mentorship preferences
-router.post("/save-preferences", isAuthenticated, (req, res) => {
+/// Save mentorship preferences 
+router.post("/save-preferences", isAuthenticated, async (req, res) => {
   const userId = req.session.user.id;
-  const { role, transplantType, transplantYear, goals, meetingPref, sportsInterest } = req.body;
+  const { sessionId, role, transplantType, transplantYear, goals, meetingPref, sportsInterest } = req.body;
 
-  console.log("🔸 /save-preferences hit", { userId, role, transplantType, transplantYear });
+  if (!sessionId || !role) {
+    return res.status(400).json({ success: false, error: 'Missing sessionId or role' });
+  }
 
-  db.run(`
+  // 🔄 Ensure application exists
+  await db.ensureApplicationExists(userId, sessionId, role);
+  const applicationId = await db.getApplicationIdForUser(userId);
+
+  console.log("🔸 /save-preferences hit", { userId, applicationId, role, transplantType, transplantYear });
+
+  db.run(
+    `
     INSERT OR REPLACE INTO mentorship_preferences 
-    (user_id, role, transplant_type, transplant_year, goals, meeting_preference, sports_activities)
-    VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    (application_id, user_id, role, transplant_type, transplant_year, goals, meeting_preference, sports_activities)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `,
     [
+      applicationId,
       userId,
       role,
-      JSON.stringify(transplantType), 
+      JSON.stringify(transplantType),
       transplantYear,
       JSON.stringify(goals),
       meetingPref,
@@ -34,20 +45,28 @@ router.post("/save-preferences", isAuthenticated, (req, res) => {
         console.error("❌ Error saving preferences:", err.message);
         return res.status(500).json({ success: false, error: err.message });
       }
-      console.log("✅ Preferences saved for user:", userId);
+      console.log("✅ Preferences saved for application:", applicationId);
       res.json({ success: true });
     }
   );
 });
 
 // Save lifestyle answers
-router.post("/save-lifestyle", isAuthenticated, (req, res) => {
+router.post("/save-lifestyle", isAuthenticated, async (req, res) => {
   const userId = req.session.user.id;
-  const { answers } = req.body;
+  const { sessionId, answers } = req.body;
 
-  console.log("🔸 /save-lifestyle hit", { userId, answers });
+  if (!sessionId || !answers) {
+    return res.status(400).json({ success: false, error: 'Missing sessionId or answers' });
+  }
+
+  await db.ensureApplicationExists(userId, sessionId);
+  const applicationId = await db.getApplicationIdForUser(userId);
+
+  console.log("🔸 /save-lifestyle hit", { userId, applicationId, answers });
 
   const values = [
+    applicationId,
     userId,
     answers.physicalExerciseFrequency,
     answers.likeAnimals,
@@ -64,6 +83,7 @@ router.post("/save-lifestyle", isAuthenticated, (req, res) => {
 
   db.run(`
     INSERT OR REPLACE INTO lifestyle_answers (
+      application_id,
       user_id,
       physicalExerciseFrequency,
       likeAnimals,
@@ -76,42 +96,44 @@ router.post("/save-lifestyle", isAuthenticated, (req, res) => {
       stressHandling,
       motivationLevel,
       hadMentor
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    values,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `, values,
     function (err) {
       if (err) {
         console.error("❌ Error saving lifestyle answers:", err.message);
         return res.status(500).json({ success: false, error: err.message });
       }
-      console.log("✅ Lifestyle answers saved for user:", userId);
+      console.log("✅ Lifestyle answers saved for application:", applicationId);
       res.json({ success: true });
     }
   );
 });
 
-// Save Enneagram
-router.post("/save-enneagram", isAuthenticated, (req, res) => {
+// Save Enneagram answers
+router.post("/save-enneagram", isAuthenticated, async (req, res) => {
   const userId = req.session.user.id;
+  const applicationId = await db.getApplicationIdForUser(userId);
   const { topTypes, allScores } = req.body;
 
-  console.log("🔸 /save-enneagram hit", { userId, topTypes });
+  console.log("🔸 /save-enneagram hit", { userId, applicationId, topTypes });
 
   db.run(`
-    INSERT OR REPLACE INTO enneagram_answers (user_id, top_type, scores)
-    VALUES (?, ?, ?)`,
-    [userId, JSON.stringify(topTypes), JSON.stringify(allScores)],
+    INSERT OR REPLACE INTO enneagram_answers (
+      application_id, user_id, top_type, scores
+    ) VALUES (?, ?, ?, ?)`,
+    [applicationId, userId, JSON.stringify(topTypes), JSON.stringify(allScores)],
     function (err) {
       if (err) {
         console.error("❌ Error saving enneagram:", err.message);
         return res.status(500).json({ success: false, error: err.message });
       }
-      console.log("✅ Enneagram saved for user:", userId);
+      console.log("✅ Enneagram saved for application:", applicationId);
       res.json({ success: true });
     }
   );
 });
 
-// Get top mentor matches for current mentee (combined name format)
+// Get top mentor matches for current mentee
 router.get("/match-mentee", isAuthenticated, async (req, res) => {
   try {
     const menteeId = req.session.user.id;
@@ -131,25 +153,27 @@ router.get("/match-mentee", isAuthenticated, async (req, res) => {
   }
 });
 
-// POST /api/mark-submitted
-router.post("/mark-submitted", isAuthenticated, (req, res) => {
+// Mark form as submitted
+router.post("/mark-submitted", isAuthenticated, async (req, res) => {
   const userId = req.session.user.id;
+  const applicationId = await db.getApplicationIdForUser(userId);
 
-  db.run(`UPDATE mentorship_preferences SET submitted = 1 WHERE user_id = ?`, [userId], function (err) {
+  db.run(`UPDATE mentorship_preferences SET submitted = 1 WHERE application_id = ?`, [applicationId], function (err) {
     if (err) {
       console.error("❌ Failed to mark as submitted:", err.message);
       return res.status(500).json({ success: false });
     }
-    console.log(`✅ Form marked as submitted for user ${userId}`);
+    console.log(`✅ Form marked as submitted for application ${applicationId}`);
     res.json({ success: true });
   });
 });
 
 // Check if form is submitted
-router.get("/form-status", isAuthenticated, (req, res) => {
+router.get("/form-status", isAuthenticated, async (req, res) => {
   const userId = req.session.user.id;
+  const applicationId = await db.getApplicationIdForUser(userId);
 
-  db.get(`SELECT submitted FROM mentorship_preferences WHERE user_id = ?`, [userId], (err, row) => {
+  db.get(`SELECT submitted FROM mentorship_preferences WHERE application_id = ?`, [applicationId], (err, row) => {
     if (err) {
       console.error("❌ Failed to check form status:", err.message);
       return res.status(500).json({ success: false });
@@ -160,9 +184,5 @@ router.get("/form-status", isAuthenticated, (req, res) => {
     res.json({ success: true, submitted: row.submitted === 1 });
   });
 });
-
-
-
-
 
 module.exports = router;


### PR DESCRIPTION
Introduced application_id to track user submissions per session (supporting multiple applications per user).
The application_id is now used as the primary link across:
- `mentorship_preferences`
- `lifestyle_answers`
- `enneagram_answers`

Added backend logic to:
- Ensure application_id exists (ensureApplicationExists)
- Insert or replace records using application_id as the anchor
- Matching now pulls data based on the correct application context