### PR TITLE
Redirect to survey

### DIFF
--- a/Mentor-Matching-Platform/client/src/components/Survey/SurveyStart.js
+++ b/Mentor-Matching-Platform/client/src/components/Survey/SurveyStart.js
@@ -2,11 +2,17 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+// read url parameter
+// import { useSearchParams } from 'react-router-dom';
+
 const SurveyStart = () => {
   const navigate = useNavigate();
   const [selectedRole, setSelectedRole] = useState(null);
   const [profile, setProfile] = useState({});
   const [isLocked, setIsLocked] = useState(false);
+  // get sessionId and role from url
+  // const sessionId = searchParams.get('sessionId');
+  // const role      = searchParams.get('role');
 
   useEffect(() => {
     fetch('/api/form-status', {

--- a/Mentor-Matching-Platform/client/src/pages/Mentorship/MentorshipSessionDetailPage.js
+++ b/Mentor-Matching-Platform/client/src/pages/Mentorship/MentorshipSessionDetailPage.js
@@ -64,7 +64,8 @@ const MentorshipSessionDetailPage = () => {
         alert('Application sent successfully!');
         setApplied(true);
         setAppliedRole(role);
-        navigate('/sessions');
+        // Navigate into survey flow, passing sessionId and role as query params
+        navigate(`/survey?sessionId=${id}&role=${role}`);
       } else {
         const data = await resp.json();
         alert(data.error || 'Failed to apply');


### PR DESCRIPTION

This PR streamlines the user experience by sending applicants directly into the survey flow immediately after they click **Apply** on a session. Instead of returning to the sessions list, users are redirected to the `SurveyPage` with the relevant `sessionId` and `role` passed as URL parameters.

**Changes:**

* **`MentorshipSessionDetailPage.js`**

  * Updated `handleApply` to call `navigate('/survey?sessionId=...&role=...')` on success.
  * Kept existing alert and state-update logic unchanged.
* **`SurveyStart.jsx`**

  * Reads `sessionId` and `role` from `useSearchParams`.


