### PR TITLE
create admin application detail page

### DIFF
--- a/Mentor-Matching-Platform/client/src/pages/Admin/AdminApplicationDetailPage.jsx
+++ b/Mentor-Matching-Platform/client/src/pages/Admin/AdminApplicationDetailPage.jsx
@@ -1,56 +1,46 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 
-// src/pages/AdminApplicationDetailPage.jsx
-import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-
-// AdminApplicationDetailPage: view and update application status
-export default function AdminApplicationDetailPage() {
+function AdminApplicationDetailPage() {
   const { sessionId, applicationId } = useParams();
   const [app, setApp] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [updating, setUpdating] = useState(false);
 
-  // Fetch application details
   useEffect(() => {
     fetch(`/api/admin/sessions/${sessionId}/applications/${applicationId}`)
-      .then(res => {
-        if (!res.ok) throw new Error('Failed to load application');
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to fetch application: ${res.status}`);
         return res.json();
       })
-      .then(data => {
+      .then((data) => {
         setApp(data);
         setLoading(false);
       })
-      .catch(err => {
-        console.error('Fetch application error:', err);
+      .catch((err) => {
+        console.error("Fetch application error:", err);
         setError(err);
         setLoading(false);
       });
   }, [sessionId, applicationId]);
 
-  // Update status helper
   const updateStatus = (newStatus) => {
-    console.log('Updating status to', newStatus);
     setUpdating(true);
-    fetch(
-      `/api/admin/sessions/${sessionId}/applications/${applicationId}`,
-      {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: newStatus }),
-      }
-    )
-      .then(res => {
+    fetch(`/api/admin/sessions/${sessionId}/applications/${applicationId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: newStatus }),
+    })
+      .then((res) => {
         if (!res.ok) throw new Error(`Status update failed: ${res.status}`);
         return res.json();
       })
       .then(({ status }) => {
-        console.log('Status updated to', status);
-        setApp(prev => ({ ...prev, status }));
+        setApp((prev) => ({ ...prev, status }));
       })
-      .catch(err => {
-        console.error('Update status error:', err);
+      .catch((err) => {
+        console.error("Update status error:", err);
         setError(err);
       })
       .finally(() => setUpdating(false));
@@ -60,60 +50,152 @@ export default function AdminApplicationDetailPage() {
   if (error) return <p className="p-4 text-red-500">Error: {error.message}</p>;
 
   return (
-    <div className="p-6">
-      <h2 className="text-2xl font-semibold mb-6">Application Details</h2>
-
-      {/* Applicant Email */}
-      <div className="mb-4">
-        <h3 className="text-lg font-medium">Email</h3>
-        <p>{app.email}</p>
+    <div className="max-w-4xl mx-auto bg-white p-8 rounded shadow">
+      {/* Top header */}
+      <div className="flex justify-between items-start mb-6">
+        <div>
+          <h2 className="text-2xl font-semibold">Mentorship Application Details</h2>
+          <p className="text-sm text-gray-500 mt-1">Session ID: {sessionId}</p>
+        </div>
       </div>
 
       {/* Applied Role */}
       <div className="mb-6">
-        <h3 className="text-lg font-medium mb-1">Applied Role</h3>
-        <p>{app.role}</p>
+        <h3 className="text-lg font-medium">Applied Role</h3>
+        <p>{app?.role}</p>
       </div>
 
-      {/* Personal Profile Placeholder */}
+      {/* Personal Profile */}
       <div className="mb-6">
-        <h3 className="text-lg font-medium mb-1">Personal Profile</h3>
-        <div className="p-4 bg-gray-50 rounded">Profile details placeholder</div>
+        <h3 className="text-lg font-medium">Personal Profile</h3>
+        <div className="p-4 bg-gray-50 rounded text-gray-700">
+          {app?.profile ? (
+            Object.entries(app.profile).map(([key, value]) => (
+              <div key={key} className="mb-1">
+                <span className="font-semibold capitalize">{key}:</span>{" "}
+                <span>{String(value)}</span>
+              </div>
+            ))
+          ) : (
+            "No profile information available."
+          )}
+        </div>
       </div>
 
-      {/* Mentorship Preferences Placeholder */}
+      {/* Mentorship Preferences */}
       <div className="mb-6">
-        <h3 className="text-lg font-medium mb-1">Mentorship Preferences</h3>
-        <div className="p-4 bg-gray-50 rounded">Preferences placeholder</div>
+        <h3 className="text-lg font-medium">Mentorship Preferences</h3>
+        <div className="p-4 bg-gray-50 rounded text-gray-700">
+          {app?.preferences ? (
+            Object.entries(app.preferences).map(([key, value]) => (
+              <div key={key} className="mb-1">
+                <span className="font-semibold capitalize">{key}:</span>{" "}
+                <span>{String(value)}</span>
+              </div>
+            ))
+          ) : (
+            "No preferences information available."
+          )}
+        </div>
       </div>
+
+      {app?.role?.toLowerCase() === "mentee" && (
+        <>
+          {/* Recommended Mentors */}
+          <div className="mb-6">
+            <h3 className="text-lg font-medium">Recommended Mentors</h3>
+            {app?.recommendedMentors && app.recommendedMentors.length > 0 ? (
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+                {app.recommendedMentors.map((mentor) => (
+                  <div
+                    key={mentor.id}
+                    className="flex items-center space-x-3 p-3 border rounded shadow-sm hover:shadow-md transition"
+                  >
+                    <img
+                      src={mentor.avatar || "/placeholder-avatar.jpg"}
+                      alt={mentor.name}
+                      className="w-12 h-12 rounded-full object-cover"
+                    />
+                    <div className="font-medium">{mentor.name}</div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-gray-500">No recommended mentors available.</p>
+            )}
+          </div>
+
+          {/* Assign Another Mentor */}
+          <div className="mb-6">
+            <h3 className="text-lg font-medium">Assign Another Mentor</h3>
+            <div className="p-4 bg-gray-50 rounded text-gray-700">
+              <input
+                type="text"
+                placeholder="Search mentors..."
+                className="w-full p-2 border rounded"
+              />
+              <p className="mt-2 text-gray-500 text-sm">Mentor details will appear here after selection</p>
+            </div>
+          </div>
+
+      {/* Photo */}
+      <div className="mb-6">
+        <h3 className="text-lg font-medium">Photo</h3>
+        <img
+          src={app?.role === "Mentor" ? "/mentor-photo.jpg" : "/mentee-photo.jpg"}
+          alt={`${app?.role} Session`}
+          className="rounded-lg w-full max-w-2xl mx-auto"
+        />
+      </div>
+      
+      {/* Admin Comments */}
+      <div className="mb-6">
+            <h3 className="text-lg font-medium">Admin Comments</h3>
+            {app?.adminComments && app.adminComments.length > 0 ? (
+              <ul className="space-y-4 max-h-64 overflow-y-auto border p-4 rounded bg-gray-50">
+                {app.adminComments.map((comment) => (
+                  <li key={comment.id} className="border-b pb-2 last:border-b-0">
+                    <div className="text-xs text-gray-500">
+                      {new Date(comment.timestamp).toLocaleString()} by {comment.author}
+                    </div>
+                    <div className="mt-1 text-gray-700 whitespace-pre-wrap">{comment.content}</div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-gray-500">No admin comments available.</p>
+            )}
+          </div>
+        </>
+      )}
 
       {/* Current Status */}
       <div className="mb-6">
-        <h3 className="text-lg font-medium mb-1">Current Status</h3>
+        <h3 className="text-lg font-medium">Current Status</h3>
         <span
           className={`px-2 py-1 rounded-full text-sm ${
-            app.status === 'approved'
-              ? 'bg-green-100 text-green-800'
-              : app.status === 'onhold'
-              ? 'bg-yellow-100 text-yellow-800'
-              : 'bg-gray-100 text-gray-800'
+            app?.status === "approved"
+              ? "bg-green-100 text-green-800"
+              : app?.status === "onhold"
+              ? "bg-yellow-100 text-yellow-800"
+              : "bg-gray-100 text-gray-800"
           }`}
         >
-          {app.status}
+          {app?.status}
         </span>
       </div>
 
       {/* Action Buttons */}
       <div className="flex space-x-4">
         <button
-          onClick={() => updateStatus('approved')}
+          onClick={() => updateStatus("approved")}
           disabled={updating}
           className="px-4 py-2 bg-green-600 text-white rounded"
         >
           Approve
         </button>
         <button
-          onClick={() => updateStatus('onhold')}
+          onClick={() => updateStatus("onhold")}
           disabled={updating}
           className="px-4 py-2 bg-yellow-500 text-white rounded"
         >
@@ -124,3 +206,4 @@ export default function AdminApplicationDetailPage() {
   );
 }
 
+export default AdminApplicationDetailPage;


### PR DESCRIPTION
This pull request includes a series of interface and logic enhancements to the Admin Application Detail page, mainly targeting mentorship session visibility and minor UI improvements.

Summary of changes:

Added session ID display under the page title for clearer context (https://github.com/HohhotDog/Transplant-Australia-Mentoring-Platform/commit/e1a95aaa21a89b3e3ddf68e8b9e0a10ade219a35)
Improved layout structure and spacing for better readability (https://github.com/HohhotDog/Transplant-Australia-Mentoring-Platform/commit/6d8aa27cbab61bd5b85cb822a78aa868551b1001)
Fixed search box behavior for better usability (https://github.com/HohhotDog/Transplant-Australia-Mentoring-Platform/commit/b7816f3321d7d7ae5c43f3d20529a4fa4cd10f7e)
Updated mentee role logic to ensure extra sections render correctly (https://github.com/HohhotDog/Transplant-Australia-Mentoring-Platform/commit/81048d2e83cc6097f093108ed5cbd55c78972c21)
Reworded admin comment section for clarity (https://github.com/HohhotDog/Transplant-Australia-Mentoring-Platform/commit/d795f09da78e5e82e44384ef9acbf38203a01683)
Minor style tweaks to polish the page appearance (https://github.com/HohhotDog/Transplant-Australia-Mentoring-Platform/commit/85562a4ec0e0eb07261172a592e86960bd302a94)
Removed one redundant commit to keep history clean and focused.
Due to unexpected file changes, I created a new pull request to re-implement the same functionality as the previous one.