### PR TITLE
Integrate real mentor search and pairing endpoints in AdminApplicatio…

### DIFF
--- a/Mentor-Matching-Platform/client/src/pages/Admin/AdminApplicationDetailPage.jsx
+++ b/Mentor-Matching-Platform/client/src/pages/Admin/AdminApplicationDetailPage.jsx
@@ -2,21 +2,14 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 // Toggle mock data for testing
-const USE_MOCK_RECOMMEND = true;
+const USE_MOCK_RECOMMEND = false;
 
 function AdminApplicationDetailPage() {
   const { sessionId, applicationId } = useParams();
   const [app, setApp] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [recommendedMentors, setRecommendedMentors] = useState(
-    USE_MOCK_RECOMMEND
-      ? [
-          { id: 101, name: 'Mock Mentor A', avatar: null },
-          { id: 102, name: 'Mock Mentor B', avatar: 'https://via.placeholder.com/150' },
-        ]
-      : []
-  );
+  const [recommendedMentors, setRecommendedMentors] = useState([]);
   const [recLoading, setRecLoading] = useState(false);
   const [updating, setUpdating] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
@@ -49,7 +42,13 @@ function AdminApplicationDetailPage() {
           if (!res.ok) throw new Error(`Failed to fetch recommended mentors: ${res.status}`);
           return res.json();
         })
-        .then(data => setRecommendedMentors(data))
+        .then(data => {
+          if (data.success) {
+            setRecommendedMentors(data.matches);
+          } else {
+            console.error('Match API error:', data.message);
+          }
+        })
         .catch(err => console.error('Error fetching recommended mentors:', err))
         .finally(() => setRecLoading(false));
     }

--- a/Mentor-Matching-Platform/server/index.js
+++ b/Mentor-Matching-Platform/server/index.js
@@ -10,6 +10,8 @@ const securityRoutes = require("./routes/security");
 const surveyRoutes = require("./routes/survey");
 const matchRoutes = require("./routes/match");
 const avatarRoutes = require("./routes/avatar");
+const mentorsRouter = require("./routes/mentors");
+const matchingPairsRouter = require("./routes/matching-pairs");
 
 const sessionRoutes = require("./routes/sessions");
 const seedSessions = require("./scripts/seedSessions");
@@ -53,6 +55,8 @@ app.use("/api", surveyRoutes);
 app.use("/api", matchRoutes);
 app.use("/api", sessionRoutes);
 app.use("/api", avatarRoutes);
+app.use("/api/mentors", mentorsRouter);
+app.use("/api/matching-pairs", matchingPairsRouter);
 
 // admin routes
 const adminRoutes = require("./routes/admin");

--- a/Mentor-Matching-Platform/server/routes/matching-pairs.js
+++ b/Mentor-Matching-Platform/server/routes/matching-pairs.js
@@ -1,0 +1,48 @@
+// server/routes/matching-pairs.js
+const express = require('express');
+const router = express.Router();
+const db = require('../db'); // adjust this path to your DB instance
+
+/**
+ * POST /api/matching-pairs
+ * Request body: { sessionId, applicationId, mentorId }
+ * 1. Look up the application’s user_id as menteeId.
+ * 2. Insert a new record into matching_pairs.
+ * 3. Return the created pair.
+ */
+router.post('/', (req, res) => {
+  const { sessionId, applicationId, mentorId } = req.body;
+
+  // 1. Retrieve the user_id (mentee) from applications
+  const lookupSql = `SELECT user_id AS menteeId FROM applications WHERE id = ?`;
+  db.get(lookupSql, [applicationId], (err, row) => {
+    if (err || !row) {
+      console.error('Error fetching application:', err);
+      return res.status(500).json({ error: 'Unable to retrieve application' });
+    }
+    const menteeId = row.menteeId;
+
+    // 2. Insert pairing record
+    const insertSql = `
+      INSERT INTO matching_pairs (session_id, mentor_id, mentee_id)
+      VALUES (?, ?, ?)
+    `;
+    db.run(insertSql, [sessionId, mentorId, menteeId], function(err) {
+      if (err) {
+        console.error('Error inserting matching pair:', err);
+        return res.status(500).json({ error: err.message });
+      }
+
+      // 3. Respond with new record details
+      res.json({
+        id: this.lastID,
+        sessionId,
+        mentorId,
+        menteeId,
+        createdAt: new Date().toISOString()
+      });
+    });
+  });
+});
+
+module.exports = router;

--- a/Mentor-Matching-Platform/server/routes/mentors.js
+++ b/Mentor-Matching-Platform/server/routes/mentors.js
@@ -1,0 +1,33 @@
+// server/routes/mentors.js
+const express = require('express');
+const router = express.Router();
+const db = require('../db'); // adjust this path to your DB instance
+
+/**
+ * GET /api/mentors?search=term
+ * Search mentors by name, pulling name and avatar from the profiles table.
+ * Returns an array of { id, name, avatar }.
+ */
+router.get('/', (req, res) => {
+  const term = `%${req.query.search || ''}%`;
+  const sql = `
+    SELECT 
+      u.id,
+      p.first_name || ' ' || p.last_name AS name,
+      p.profile_picture_url AS avatar
+    FROM users u
+    JOIN profiles p ON p.user_id = u.id
+    WHERE u.account_type = 'mentor'
+      AND (p.first_name || ' ' || p.last_name) LIKE ?
+    LIMIT 20
+  `;
+  db.all(sql, [term], (err, rows) => {
+    if (err) {
+      console.error('Search mentors failed:', err);
+      return res.status(500).json({ error: err.message });
+    }
+    res.json(rows);
+  });
+});
+
+module.exports = router;


### PR DESCRIPTION
Description:
This PR updates the frontend to remove mock data and wire up the real backend endpoints for mentor recommendation, search, and pairing. Key changes include:
	•	Disable mock recommendations
	•	Switched USE_MOCK_RECOMMEND to false and removed the mock mentors array.
	•	Fetch real recommended mentors
	•	In the initial useEffect, fetch from GET /api/match-mentee?sessionId={sessionId}
	•	Parse the response as { success, matches } and populate recommendedMentors with matches.
	•	Handle success: false by logging errors.
	•	Add mentor search input
	•	Introduce searchTerm, searchResults, searchLoading, and searchError state.
	•	On input change, query GET /api/mentors?search={searchTerm} and display results.
	•	Show loading, error, empty-state messages appropriately.
	•	Enable pairing on click
	•	Clicking any mentor card (recommended or search result) now calls POST /api/matching-pairs with { sessionId, applicationId, mentorId }.
	•	Disabled duplicate clicks via an updating flag.
	•	UI feedback placeholders
	•	Added console logging for success and error cases (to be replaced with user-facing toasts later).